### PR TITLE
add examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 HashTable
 =========
 
-Group a list of signals into one hash table signal. The output signal will contain an attribute for each evaluated **key** and the value of the **key** attribute will be a list with an item of **value** for each matching signal.
+Group a list of signals into one hash table Signal. The output Signal will contain an attribute for each evaluated **key** and the value of the **key** attribute will be a **list** with an item of **value** for each matching signal.
 
-If **one_value** is True, the Signal attributes will be just a single matching value instead of a list of all matching values. If multiple matches, then the last signal processed will be the value used.
+If `one_value` is `True`, the Signal attributes will have a single matching value instead of a list of all matching values. If multiple matches, then the last input signal processed will be the value used.
 
-If **group_by** is used, a Signal for each value in the **group_by** attribute will be produced.
+If **group_by** is defined, a Signal for each value in the **group_by** attribute will be produced.
 
 Properties
 ----------
@@ -33,9 +33,9 @@ Output
 ------
 For each input list of signals there is one output signal. It has an attribute for each **key** and that attribute is a list with a **value** for each corresponding input signal.
 
-If **one_value** is True, then the signal values are a single item instead of a list of all matching values.
+If `one_value` is `True`, then the signal values are a single item instead of a list of all matching values.
 
-If **group_by** is defined, that attribute will effectively define a new input list. One signal will be output for each value found in the **group_by** attribute.
+If **group_by** is defined, that attribute will effectively define a new input list of signals. One signal will be output for each value found in the **group_by** attribute.
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 HashTable
 =========
 
-Group a list of input signals into one hash table signal. The output signal will contain an attribute for each evaluated **key** and the **value** of the key will be a **list** containing each value found with that key.
+Group a list of input signals into one hash table signal. The output signal will contain an attribute for each evaluated **key** and the **value** of the key will be a **list** containing each value with a matching key.
 
 If `one_value` is `True`, the output signal's attributes will each have a single value instead of a list of all values. If multiple matching keys are found, the value of the last input signal processed will be the value of the key.
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 HashTable
 =========
 
-Group a list of signals into one hash table Signal. The output Signal will contain an attribute for each evaluated **key** and the value of the **key** attribute will be a **list** with an item of **value** for each matching signal.
+Group a list of signals into one hash table Signal. The output Signal will contain an attribute for each evaluated **key** and the **value** of the **key** attribute will be a **list** with an item of **value** for each matching signal.
 
-If `one_value` is `True`, the Signal attributes will have a single matching value instead of a list of all matching values. If multiple matches, then the last input signal processed will be the value used.
+If `one_value` is `True`, the Signal attributes will have a single matching value instead of a list of all values with a matching key. If multiple matches, then the last input signal processed will be the value used.
 
-If **group_by** is defined, a Signal for each value in the **group_by** attribute will be produced.
+If `group_by` is defined, a Signal for each value in the `group_by` attribute will be produced.
 
 Properties
 ----------
-
--   **key**: Expression property. Evaluates to key attribute on output signal.
--   **value**: Expression property. Evaluates to a value to be placed in an output signal list.
+-   **key**: Expression property. Evaluates to key attribute on output Signal.
+-   **value**: Expression property. Evaluates to a value in a list of values with a matching key.
 -   **group_by**: Expression to group signals by.
--   **group_attr**: When *group_by* is used, this is the value that will be stored in a Signal attribute called, in this case, "group".
--   **one_value**: If True, the output signals have attribute values that are a single value instead of a list of all matching values. When multiple signals match one key, the value used is from the last signal processed.
-
+-   **group_attr**: When `group_by` is used, this is the value that will be stored in a Signal attribute called, in this case, `group`.
+-   **one_value**: If `True`, the output signals have attribute values that are a single value instead of a list of all matching values. When multiple signals match one key, the value used is from the last signal processed.
 
 Dependencies
 ------------
@@ -25,17 +23,13 @@ Commands
 --------
 None
 
-Input
------
-The signals should have attributes that can be evaluated by **key** and **value**.
-
 Output
 ------
-For each input list of signals there is one output signal. It has an attribute for each **key** and that attribute is a list with a **value** for each corresponding input signal.
+For each input list of signals there is one output Signal. It has an attribute for each **key** and that attribute is a list with a **value** for each corresponding input signal.
 
-If `one_value` is `True`, then the signal values are a single item instead of a list of all matching values.
+If `one_value` is `True`, then the Signal values are a single item instead of a list of all matching values.
 
-If **group_by** is defined, that attribute will effectively define a new input list of signals. One signal will be output for each value found in the **group_by** attribute.
+If `group_by` is defined, that attribute will effectively define a new input list of signals. One Signal will be output for each value found in the `group_by` attribute.
 
 Examples
 --------
@@ -52,13 +46,12 @@ Examples
 ]
 ```
 
-**Block Config with _key_ based on _type_**
+**Block Config with _key_ based on `type`**
 
 ```
 key: {{ $type }},
 value: {{ $size }},
 one_value: False
-
 ```
 
 **Signal Output**
@@ -71,7 +64,7 @@ one_value: False
   "group": ""
 }
 ```
-**Block Config with _key_ based on _color_**
+**Block Config with _key_ based on `color`**
 
 ```
 key: {{ $color }}
@@ -89,7 +82,7 @@ one_value: False
 }
 ```
 
-**Block Config with _key_ based on _type_ and _One Value Per Key_ checked**
+**Block Config with _key_ based on `color` and _One Value Per Key_ checked**
 
 ```
 key: {{ $color }}
@@ -107,7 +100,7 @@ one_value: True
 }
 ```
 
-**Block Config using _group_by_ to spit out multiple signals**
+**Block Config using `group_by` to spit out multiple signals**
 
 ```
 key: {{ $type }}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 HashTable
 =========
 
-Group a list of signals into one hash table Signal. The output Signal will contain an attribute for each evaluated **key** and the **value** of the **key** attribute will be a **list** with an item of **value** for each matching signal.
+Group a list of input signals into one hash table signal. The output signal will contain an attribute for each evaluated **key** and the **value** of the key will be a **list** containing each value found with that key.
 
-If `one_value` is `True`, the Signal attributes will have a single matching value instead of a list of all values with a matching key. If multiple matches, then the last input signal processed will be the value used.
+If `one_value` is `True`, the output signal's attributes will have a single value instead of a list of all values. If multiple matching keys are found, the value of the last input signal processed will be the value of the key.
 
-If `group_by` is defined, a Signal for each value in the `group_by` attribute will be produced.
+If `group_by` is defined, an output signal will be produced for each value in the `group_by` attribute.
 
 Properties
 ----------
--   **key**: Expression property. Evaluates to key attribute on output Signal.
+-   **key**: Expression property. Evaluates to a key attribute on output signal.
 -   **value**: Expression property. Evaluates to a value in a list of values with a matching key.
 -   **group_by**: Expression to group signals by.
--   **group_attr**: When `group_by` is used, this is the value that will be stored in a Signal attribute called, in this case, `group`.
--   **one_value**: If `True`, the output signals have attribute values that are a single value instead of a list of all matching values. When multiple signals match one key, the value used is from the last signal processed.
+-   **group_attr**: When `group_by` is used, this is the value that will be stored in a signal attribute called, in this case, `group`.
+-   **one_value**: If `True`, the output signal's attributes have a single value instead of a list of values. When multiple input signals have the same key, the value of the last signal processed is the value of the output signal's attribute.
 
 Dependencies
 ------------
@@ -25,11 +25,11 @@ None
 
 Output
 ------
-For each input list of signals there is one output Signal. It has an attribute for each **key** and that attribute is a list with a **value** for each corresponding input signal.
+For each list of input signals there is one output signal. It has an attribute for each **key** and that attribute is a **list** containing a **value** for each matching key found in an input signal.
 
-If `one_value` is `True`, then the Signal values are a single item instead of a list of all matching values.
+If `one_value` is `True`, then each attribute on the output signal has a value that is a single item instead of a list of all matching values.
 
-If `group_by` is defined, that attribute will effectively define a new input list of signals. One Signal will be output for each value found in the `group_by` attribute.
+If `group_by` is defined, the `group_by` attribute will effectively define a new list of input signals. One output signal will be generated for each value found in the `group_by` attribute.
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -1,100 +1,11 @@
 HashTable
 =========
 
-Group a list of signals into one hash table signal. The output signal will contain an attribute for each evaluated *key* and the value of that attribute will be a list with an item of *value* for each matching signal.
+Group a list of signals into one hash table signal. The output signal will contain an attribute for each evaluated **key** and the value of the **key** attribute will be a list with an item of **value** for each matching signal.
 
-If *one_value* is True, the Signal attributes will be just a single matching value instead of a list of all matching values. If multiple matches, then the last signal processed will be the value used.
+If **one_value** is True, the Signal attributes will be just a single matching value instead of a list of all matching values. If multiple matches, then the last signal processed will be the value used.
 
-If *group_by* is used, a Signal attribute (key) with the default (pre-assigned) name *group* will have the value of *group_by* in the output signal.
-
-**Example:**
-
-_Signals Input_:
-
-```python
-[
-{ "type": "important", "color": "red", "age": 32 },
-{ "type": "minor", "color": "red", "age": 9 },
-{ "type": "important", "color": "orange", "age": 14 },
-{ "type": "standard", "color": "red", "age": 1 }
-]
-```
-
-_Block Config with key based on "type"_:
-
-```python
-key : {{ $type }}
-value : {{ $age }}
-one_value: False
-```
-
-_Signal Output_:
-
-```python
-{
-    "important": [32, 14],
-    "standard": [1],
-    "minor": [9],
-    "group": ""
-}
-```
-_Block Config with key based on "color"_:
-
-```python
-key : {{ $color }}
-value : {{ $age }}
-one_value: False
-```
-
-_Signal Output_:
-
-```python
-{
-    "red": [32, 9, 1],
-    "orange": [14],
-}
-```
-
-_Block Config with key based on "type" and "One Value Per Key" checked (one_value = True)_:
-
-```python
-key : {{ $type }}
-value : {{ $age }}
-one_value: True
-```
-
-_Signal Output_:
-
-```python
-{
-    "important": [14],
-    "standard": [1],
-    "minor": [9]
-    "group": ""
-}
-```
-
-_Block Config using *group_by* to assign name to the *group* Signal attribute_:
-
-```python
-key : {{ $type }}
-value : {{ $age }}
-group_by: "priority"
-one_value: False
-```
-
-_Signal Output_:
-
-```python
-[
-  {
-    "group": "priority",
-    "important": [32, 14],
-    "standard": [1],
-    "minor": [9]
-  }
-]
-```
+If **group_by** is used, a Signal for each value in the **group_by** attribute will be produced.
 
 Properties
 ----------
@@ -102,7 +13,7 @@ Properties
 -   **key**: Expression property. Evaluates to key attribute on output signal.
 -   **value**: Expression property. Evaluates to a value to be placed in an output signal list.
 -   **group_by**: Expression to group signals by.
--   **group_attr**: When *group_by* is used, this is the value that will be stored in a Signal attribute called, in this case, 'group'.
+-   **group_attr**: When *group_by* is used, this is the value that will be stored in a Signal attribute called, in this case, "group".
 -   **one_value**: If True, the output signals have attribute values that are a single value instead of a list of all matching values. When multiple signals match one key, the value used is from the last signal processed.
 
 
@@ -116,8 +27,100 @@ None
 
 Input
 -----
-The signals should have attributes that can be evaluated by *key* and *value*.
+The signals should have attributes that can be evaluated by **key** and **value**.
 
 Output
----------
-For each input list of signals there is one output signal. It has an attribute for each *key* and that attribute is a list with a *value* for each corresponding input signal. If *group_by* is defined, it will become the value of the Signal attribute *group*. If *one_value* is True, then the signal values are a single item instead of a list of all matching values.
+------
+For each input list of signals there is one output signal. It has an attribute for each **key** and that attribute is a list with a **value** for each corresponding input signal.
+
+If **one_value** is True, then the signal values are a single item instead of a list of all matching values.
+
+If **group_by** is defined, that attribute will effectively define a new input list. One signal will be output for each value found in the **group_by** attribute.
+
+Examples
+--------
+
+**Signals Input**
+
+```python
+[
+{ "type": "shirt", "color": "red", "size": 10},
+{ "type": "shirt", "color": "red", "size": 14},
+{ "type": "shirt", "color": "orange", "size": 12},
+{ "type": "scarf", "color": "red", "size": "M"},
+{ "type": "shoes", "color": "orange", "size": 8}
+]
+```
+
+**Block Config with _key_ based on _type_**
+
+```
+key: {{ $type }},
+value: {{ $size }},
+one_value: False
+
+```
+
+**Signal Output**
+
+```python
+{
+  "shoes": [8],
+  "scarf": ["M"],
+  "shirt": [10, 14, 12],
+  "group": ""
+}
+```
+**Block Config with _key_ based on _color_**
+
+```
+key: {{ $color }}
+value: {{ $type }}
+one_value: False
+```
+
+**Signal Output**
+
+```python
+{
+  "orange": ["shirt", "shoes"],
+  "red": ["shirt", "shirt", "scarf"],
+  "group": ""
+}
+```
+
+**Block Config with _key_ based on _type_ and _One Value Per Key_ checked**
+
+```
+key: {{ $color }}
+value: {{ $type }}
+one_value: True
+```
+
+**Signal Output**
+
+```python
+{
+  "red": "scarf",
+  "orange": "shoes",
+  "group": ""
+}
+```
+
+**Block Config using _group_by_ to spit out multiple signals**
+
+```
+key: {{ $type }}
+value: {{ $size }}
+group_by: {{ $color }}
+one_value: False
+```
+
+**Signal Output**
+
+```python
+[
+  {"group": "orange", "shoes": [8], "shirt": [12]},
+  {"group": "red", "scarf": ["M"], "shirt": [10, 14]}
+]
+```

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ Examples
 
 **Block Config with _key_ based on `type`**
 
-**Key** `{{ $type }}`
-**Value** `{{ $size }}`
-** One Value Per Key** `False`
+```
+key: {{ $type }},
+value: {{ $size }},
+one_value: False
+```
 
 **Output Signal**
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If `group_by` is defined, that attribute will effectively define a new input lis
 Examples
 --------
 
-**Signals Input**
+**Input Signals**
 
 ```python
 [
@@ -48,13 +48,11 @@ Examples
 
 **Block Config with _key_ based on `type`**
 
-```
-key: {{ $type }},
-value: {{ $size }},
-one_value: False
-```
+**Key** `{{ $type }}`
+**Value** `{{ $size }}`
+** One Value Per Key** `False`
 
-**Signal Output**
+**Output Signal**
 
 ```python
 {
@@ -72,7 +70,7 @@ value: {{ $type }}
 one_value: False
 ```
 
-**Signal Output**
+**Output Signal**
 
 ```python
 {
@@ -90,7 +88,7 @@ value: {{ $type }}
 one_value: True
 ```
 
-**Signal Output**
+**Output Signal**
 
 ```python
 {
@@ -109,7 +107,7 @@ group_by: {{ $color }}
 one_value: False
 ```
 
-**Signal Output**
+**Output Signals**
 
 ```python
 [

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ HashTable
 
 Group a list of input signals into one hash table signal. The output signal will contain an attribute for each evaluated **key** and the **value** of the key will be a **list** containing each value found with that key.
 
-If `one_value` is `True`, the output signal's attributes will have a single value instead of a list of all values. If multiple matching keys are found, the value of the last input signal processed will be the value of the key.
+If `one_value` is `True`, the output signal's attributes will each have a single value instead of a list of all values. If multiple matching keys are found, the value of the last input signal processed will be the value of the key.
 
 If `group_by` is defined, an output signal will be produced for each value in the `group_by` attribute.
 
@@ -13,7 +13,7 @@ Properties
 -   **value**: Expression property. Evaluates to a value in a list of values with a matching key.
 -   **group_by**: Expression to group signals by.
 -   **group_attr**: When `group_by` is used, this is the value that will be stored in a signal attribute called, in this case, `group`.
--   **one_value**: If `True`, the output signal's attributes have a single value instead of a list of values. When multiple input signals have the same key, the value of the last signal processed is the value of the output signal's attribute.
+-   **one_value**: If `True`, the output signal's attributes have a single value instead of a list of values. When multiple input signals match one key, the value of the last signal processed is the value used.
 
 Dependencies
 ------------
@@ -109,7 +109,7 @@ group_by: {{ $color }}
 one_value: False
 ```
 
-**Output Signals**
+**Output Signals (one for each value of `color`)**
 
 ```python
 [


### PR DESCRIPTION
added sample input and illustrated four different configs:
- two different keys
- one_value
- group_by

changed wording on group_by explanation