### PR TITLE
add examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,109 @@ Group a list of signals into one hash table signal. The output signal will conta
 
 If *one_value* is True, the Signal attributes will be just a single matching value instead of a list of all matching values. If multiple matches, then the last signal processed will be the value used.
 
+If *group_by* is used, a Signal attribute (key) with the default (pre-assigned) name *group* will have the value of *group_by* in the output signal.
+
+**Example:**
+
+_Signals Input_:
+
+```python
+[
+{ "type": "important", "color": "red", "age": 32 },
+{ "type": "minor", "color": "red", "age": 9 },
+{ "type": "important", "color": "orange", "age": 14 },
+{ "type": "standard", "color": "red", "age": 1 }
+]
+```
+
+#### basic config with key based on "type"
+_Block Config_:
+
+```python
+key : {{ $type }}
+value : {{ $age }}
+one_value: False
+```
+
+_Signal Output_:
+
+```python
+{
+    "important": [32, 14],
+    "standard": [1],
+    "minor": [9],
+    "group": ""
+}
+```
+#### basic config with key based on "color"
+_Block Config_:
+
+```python
+key : {{ $color }}
+value : {{ $age }}
+one_value: False
+```
+
+_Signal Output_:
+
+```python
+{
+    "red": [32, 9, 1],
+    "orange": [14],
+}
+```
+
+#### basic config with key based on "type" and "One Value Per Key" checked (one_value = True)
+
+_Block Config_:
+
+```python
+key : {{ $type }}
+value : {{ $age }}
+one_value: True
+```
+
+_Signal Output_:
+
+```python
+{
+    "important": [14],
+    "standard": [1],
+    "minor": [9]
+    "group": ""
+}
+```
+#### config using *group_by* to assign name to *group* Signal attribute
+
+_Block Config_:
+
+```python
+key : {{ $type }}
+value : {{ $age }}
+group_by: "priority"
+one_value: False
+```
+
+_Signal Output_:
+
+```python
+[
+  {
+    "group": "priority",
+    "important": [32, 14],
+    "standard": [1],
+    "minor": [9]
+  }
+]
+```
+
 Properties
 --------------
 
--   **key**: Expression property. Evaluates to attribute on output signal.
--   **value**: Expression proprety. Evaluates to a value to be placed in an output signal list.
--   **group_by**: Expression to group signals by. 
--   **group_attr**: When *group_by* is used, the name of the group will be stored in a Signal attribute by this name.
+-   **key**: Expression property. Evaluates to key attribute on output signal.
+-   **value**: Expression property. Evaluates to a value to be placed in an output signal list.
+-   **group_by**: Expression to group signals by.
+-   **group_attr**: When *group_by* is used, this is the value that will be stored in a Signal attribute called, in this case, 'group'.
 -   **one_value**: If True, the output signals have attribute values that are a single value instead of a list of all matching values. When multiple signals match one key, the value used is from the last signal processed.
 
 
@@ -29,4 +125,4 @@ The signals should have attributes that can be evaluated by *key* and *value*.
 
 Output
 ---------
-For each input list of signals there is one output signal. It has an attribute for each *key* and that attribute is a list with a *value* for each corresponding input signal. When *group_attr* is set, it will be added as a value on the output signal with a value that is the group. If *one_value* is True, then the signal values are a single item instead of a list of all matching values.
+For each input list of signals there is one output signal. It has an attribute for each *key* and that attribute is a list with a *value* for each corresponding input signal. If *group_by* is defined, it will become the value of the Signal attribute *group*. If *one_value* is True, then the signal values are a single item instead of a list of all matching values.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ _Signals Input_:
 ]
 ```
 
-#### basic config with key based on "type"
-_Block Config_:
+_Block Config with key based on "type"_:
 
 ```python
 key : {{ $type }}
@@ -39,8 +38,7 @@ _Signal Output_:
     "group": ""
 }
 ```
-#### basic config with key based on "color"
-_Block Config_:
+_Block Config with key based on "color"_:
 
 ```python
 key : {{ $color }}
@@ -57,9 +55,7 @@ _Signal Output_:
 }
 ```
 
-#### basic config with key based on "type" and "One Value Per Key" checked (one_value = True)
-
-_Block Config_:
+_Block Config with key based on "type" and "One Value Per Key" checked (one_value = True)_:
 
 ```python
 key : {{ $type }}
@@ -77,9 +73,8 @@ _Signal Output_:
     "group": ""
 }
 ```
-#### config using *group_by* to assign name to *group* Signal attribute
 
-_Block Config_:
+_Block Config using *group_by* to assign name to the *group* Signal attribute_:
 
 ```python
 key : {{ $type }}


### PR DESCRIPTION
added sample input and illustrated four different configs:
- two different keys
- one_value
- group_by

changed wording on group_by explanation